### PR TITLE
Enable max empty lines lint

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
     "function-url-quotes": "always",
     "indentation": [2, { "ignore": "inside-parens" }],
     "length-zero-no-unit": true,
+    "max-empty-lines": 1,
     "max-nesting-depth": 7,
     "no-eol-whitespace": true,
     "no-missing-end-of-source-newline": true,


### PR DESCRIPTION
This was a TODO from my original [branch](https://github.com/conversation/tc/pull/7943) on TC, I didn't do it initially because there are quite a lot of violations, and it would have introduced something we weren't enforcing with scss-lint.

![screenshot at 2018-03-20 11-22-17](https://user-images.githubusercontent.com/2295892/37629211-a6950c98-2c31-11e8-80a8-7fb6202e9d88.png)

![screenshot at 2018-03-20 11-24-00](https://user-images.githubusercontent.com/2295892/37629213-a97d40ba-2c31-11e8-86f8-2719b1740573.png)

Roughly 53 violations in TC.