### PR TITLE
Upgrade stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-stylelint-config",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Standard TC sharable config for stylelint",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/conversation/tc-stylelint-config#readme",
   "dependencies": {
-    "stylelint": "9.1.0"
+    "stylelint": "13.13.1"
   }
 }


### PR DESCRIPTION
Only thing that seems to have changed is that the "max empty lines" rule seems to pick up more errors than before even though we already had it turned on.

Basically this:
```scss
.my-cool-element {

  
  // probably a comment here
  background: red;
}
```

Becomes:
```scss
.my-cool-element {

  // probably a comment here
  background: red;
}
```

The main thing this enables us to do is upgrade the autoprefixer and browserslist packages in TC.